### PR TITLE
Add GoDoc comments across packages

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,16 +1,28 @@
 package constants
 
+// Paths and keys used throughout GAuss.
+
 const (
-	LoginPath           = "/login"
-	GoogleAuthPath      = "/auth/google"
-	CallbackPath        = "/auth/google/callback"
-	LogoutPath          = "/logout"
-	TemplatesPath       = "templates/*.html"
+	// LoginPath is the route that serves the login page.
+	LoginPath = "/login"
+	// GoogleAuthPath starts the OAuth2 flow with Google.
+	GoogleAuthPath = "/auth/google"
+	// CallbackPath receives the OAuth2 redirect from Google.
+	CallbackPath = "/auth/google/callback"
+	// LogoutPath clears the user session.
+	LogoutPath = "/logout"
+	// TemplatesPath points to embedded login templates.
+	TemplatesPath = "templates/*.html"
+	// DefaultTemplateName is the embedded login template name.
 	DefaultTemplateName = "login.html"
 
-	SessionKeyUserEmail   = "user_email"
-	SessionKeyUserName    = "user_name"
+	// SessionKeyUserEmail stores the logged-in user's email in the session.
+	SessionKeyUserEmail = "user_email"
+	// SessionKeyUserName stores the logged-in user's display name.
+	SessionKeyUserName = "user_name"
+	// SessionKeyUserPicture stores the profile image URL.
 	SessionKeyUserPicture = "user_picture"
 
+	// SessionName is the cookie name used for sessions.
 	SessionName = "gauss_session"
 )

--- a/pkg/constants/doc.go
+++ b/pkg/constants/doc.go
@@ -1,0 +1,6 @@
+// Package constants defines common string constants used throughout GAuss.
+// These include HTTP route paths, template file names, and session key names.
+// The constants centralize configuration used by the gauss and dash packages
+// so that other applications can reliably reference them when mounting GAuss
+// authentication handlers or reading session data.
+package constants

--- a/pkg/dash/doc.go
+++ b/pkg/dash/doc.go
@@ -1,0 +1,8 @@
+// Package dash contains handlers and services for rendering an authenticated
+// dashboard. It relies on a GAuss session to retrieve user information and
+// demonstrates how a calling application can serve custom pages once the user
+// has authenticated through GAuss.
+//
+// The package exposes Handlers for wiring into an http.ServeMux and a Service
+// type that extracts profile data from the current session.
+package dash

--- a/pkg/dash/handlers.go
+++ b/pkg/dash/handlers.go
@@ -12,6 +12,9 @@ type Handlers struct {
 	templates *template.Template
 }
 
+// NewHandlers returns a handler set for serving the dashboard.
+// The service is used to obtain user information from the session and the
+// provided templates are executed when rendering the dashboard page.
 func NewHandlers(service *Service, templates *template.Template) *Handlers {
 	return &Handlers{
 		service:   service,
@@ -19,12 +22,15 @@ func NewHandlers(service *Service, templates *template.Template) *Handlers {
 	}
 }
 
+// Dashboard renders the dashboard.html template using data from the session.
 func (handlers *Handlers) Dashboard(w http.ResponseWriter, r *http.Request) {
 	webSession, _ := session.Store().Get(r, constants.SessionName)
 	data := handlers.service.GetUserData(webSession)
 	handlers.templates.ExecuteTemplate(w, "dashboard.html", data)
 }
 
+// RegisterRoutes mounts the dashboard route on the supplied ServeMux at the
+// provided path.
 func (handlers *Handlers) RegisterRoutes(mux *http.ServeMux, path string) {
 	mux.HandleFunc(path, handlers.Dashboard)
 	// Add other dashboard routes

--- a/pkg/dash/service.go
+++ b/pkg/dash/service.go
@@ -9,10 +9,15 @@ type Service struct {
 	// Add any dashboard-specific dependencies
 }
 
+// NewService creates a Service for retrieving user data for the dashboard.
+// At the moment it carries no state but is designed to hold future
+// dependencies such as database connections.
 func NewService() *Service {
 	return &Service{}
 }
 
+// GetUserData extracts a minimal set of user profile fields from the current
+// session and returns them in a map that matches the dashboard template.
 func (s *Service) GetUserData(session *sessions.Session) map[string]interface{} {
 	return map[string]interface{}{
 		"Name":    session.Values[constants.SessionKeyUserName],

--- a/pkg/gauss/doc.go
+++ b/pkg/gauss/doc.go
@@ -1,0 +1,13 @@
+// Package gauss implements Google OAuth2 authentication and session management.
+//
+// It exposes a Service type that configures the OAuth2 client, generates state
+// parameters, and retrieves user information from Google. Handlers provides a
+// ready-to-use set of HTTP handlers that mount the login, callback, and logout
+// routes on a ServeMux. The package also offers AuthMiddleware to protect
+// application endpoints by ensuring a valid GAuss session is present.
+//
+// Applications can embed this package to replace custom Google authentication
+// flows. Initialize a Service with your OAuth credentials, create Handlers, and
+// register the routes with your own mux. Protected routes should be wrapped with
+// AuthMiddleware to require a logged in user.
+package gauss

--- a/pkg/gauss/middleware.go
+++ b/pkg/gauss/middleware.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 )
 
+// AuthMiddleware ensures that a valid GAuss session exists before allowing the
+// request to proceed. Unauthenticated requests are redirected to the login
+// page.
 func AuthMiddleware(nextHandler http.Handler) http.Handler {
 	return http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
 		webSession, _ := session.Store().Get(request, constants.SessionName)

--- a/pkg/session/doc.go
+++ b/pkg/session/doc.go
@@ -1,0 +1,6 @@
+// Package session wraps gorilla/sessions to provide a global cookie store used
+// by GAuss. Call NewSession with your secret key at startup to initialize the
+// store and then use Store to retrieve it whenever a handler needs access to the
+// session. The package is intentionally small so that other packages can share
+// session management without having to configure gorilla/sessions directly.
+package session

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -6,7 +6,8 @@ import (
 
 var store *gsessions.CookieStore
 
-// NewSession creates a new cookie store
+// NewSession initializes the package-level cookie store with the given secret.
+// It should be called once at application startup.
 func NewSession(secret []byte) {
 	store = gsessions.NewCookieStore(secret)
 	store.Options = &gsessions.Options{
@@ -17,7 +18,8 @@ func NewSession(secret []byte) {
 	}
 }
 
-// Store returns the global session store
+// Store returns the global session store previously created with NewSession.
+// It panics if NewSession has not been called.
 func Store() *gsessions.CookieStore {
 	if store == nil {
 		panic("session store is nil")


### PR DESCRIPTION
## Summary
- document package purpose in `constants`, `dash`, `gauss`, and `session`
- add detailed comments for exported functions and structs
- clarify OAuth and middleware behaviors

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68797f82e9c08327953b12962df07307