### PR TITLE
Add tests and enable HTTP endpoint override

### DIFF
--- a/pkg/dash/service_test.go
+++ b/pkg/dash/service_test.go
@@ -1,0 +1,22 @@
+package dash
+
+import (
+	"testing"
+
+	"github.com/gorilla/sessions"
+	"github.com/temirov/GAuss/pkg/constants"
+)
+
+func TestGetUserData(t *testing.T) {
+	svc := NewService()
+	sess := sessions.NewSession(&sessions.CookieStore{}, constants.SessionName)
+	sess.Values = map[interface{}]interface{}{
+		constants.SessionKeyUserEmail:   "e@example.com",
+		constants.SessionKeyUserName:    "tester",
+		constants.SessionKeyUserPicture: "pic",
+	}
+	data := svc.GetUserData(sess)
+	if data["Email"] != "e@example.com" || data["Name"] != "tester" || data["Picture"] != "pic" {
+		t.Fatalf("unexpected data: %+v", data)
+	}
+}

--- a/pkg/gauss/handlers_test.go
+++ b/pkg/gauss/handlers_test.go
@@ -1,0 +1,104 @@
+package gauss
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/temirov/GAuss/pkg/constants"
+	"github.com/temirov/GAuss/pkg/session"
+	"golang.org/x/oauth2"
+)
+
+// helper to create service and handlers for tests
+func newTestHandlers(t *testing.T) *Handlers {
+	session.NewSession([]byte("secret"))
+	svc, err := NewService("id", "secret", "http://localhost:8080", "/dashboard", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	handlers, err := NewHandlers(svc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handlers
+}
+
+func TestLoginRedirect(t *testing.T) {
+	h := newTestHandlers(t)
+	req := httptest.NewRequest("GET", constants.GoogleAuthPath, nil)
+	rr := httptest.NewRecorder()
+	h.Login(rr, req)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d", rr.Code)
+	}
+	if loc := rr.Header().Get("Location"); loc == "" {
+		t.Fatal("missing redirect location")
+	}
+	if len(rr.Header()["Set-Cookie"]) == 0 {
+		t.Fatal("expected session cookie")
+	}
+}
+
+func TestCallbackSuccess(t *testing.T) {
+	// Mock OAuth2 token and userinfo endpoints
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"access_token":"abc","token_type":"bearer"}`)
+	})
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{
+			"email":   "e@example.com",
+			"name":    "tester",
+			"picture": "pic",
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	h := newTestHandlers(t)
+
+	// override endpoints
+	h.service.config.Endpoint = oauth2.Endpoint{
+		AuthURL:   server.URL + "/auth",
+		TokenURL:  server.URL + "/token",
+		AuthStyle: oauth2.AuthStyleInParams,
+	}
+
+	orig := userInfoEndpoint
+	userInfoEndpoint = server.URL + "/userinfo"
+	defer func() { userInfoEndpoint = orig }()
+
+	// prepare request with session containing state
+	req := httptest.NewRequest("GET", constants.CallbackPath+"?state=s123&code=c1", nil)
+	initRR := httptest.NewRecorder()
+	sess, _ := session.Store().Get(req, constants.SessionName)
+	sess.Values["oauth_state"] = "s123"
+	sess.Save(req, initRR)
+	cookie := initRR.Result().Cookies()[0]
+	req.AddCookie(cookie)
+
+	rr := httptest.NewRecorder()
+	h.Callback(rr, req)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("expected redirect, got %d", rr.Code)
+	}
+	loc, err := rr.Result().Location()
+	if err != nil {
+		t.Fatalf("location error: %v", err)
+	}
+	if loc.Path != "/dashboard" {
+		t.Fatalf("expected redirect to /dashboard, got %s", loc.Path)
+	}
+	// verify session now contains user
+	resCookie := rr.Result().Cookies()[0]
+	chkReq := httptest.NewRequest("GET", "/", nil)
+	chkReq.AddCookie(resCookie)
+	sess2, _ := session.Store().Get(chkReq, constants.SessionName)
+	if sess2.Values[constants.SessionKeyUserEmail] != "e@example.com" {
+		t.Fatalf("user not stored in session")
+	}
+}

--- a/pkg/gauss/middleware_test.go
+++ b/pkg/gauss/middleware_test.go
@@ -1,0 +1,42 @@
+package gauss
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/temirov/GAuss/pkg/constants"
+	"github.com/temirov/GAuss/pkg/session"
+)
+
+func TestAuthMiddlewareRedirects(t *testing.T) {
+	session.NewSession([]byte("secret"))
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	handler := AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("expected redirect, got %d", rr.Code)
+	}
+}
+
+func TestAuthMiddlewarePasses(t *testing.T) {
+	session.NewSession([]byte("secret"))
+	req := httptest.NewRequest("GET", "/", nil)
+	rrInit := httptest.NewRecorder()
+	s, _ := session.Store().Get(req, constants.SessionName)
+	s.Values[constants.SessionKeyUserEmail] = "e@example.com"
+	s.Save(req, rrInit)
+	cookie := rrInit.Result().Cookies()[0]
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler := AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected ok, got %d", rr.Code)
+	}
+}

--- a/pkg/gauss/service.go
+++ b/pkg/gauss/service.go
@@ -15,6 +15,11 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
+// userInfoEndpoint specifies the URL used to retrieve profile information from
+// Google. It is a variable rather than a constant so tests can replace it with
+// a mock server endpoint.
+var userInfoEndpoint = "https://www.googleapis.com/oauth2/v2/userinfo"
+
 // GoogleUser represents a user profile retrieved from Google.
 type GoogleUser struct {
 	Email   string `json:"email"`
@@ -79,7 +84,7 @@ func (serviceInstance *Service) GenerateState() (string, error) {
 // associated with the provided OAuth2 token.
 func (serviceInstance *Service) GetUser(oauthToken *oauth2.Token) (*GoogleUser, error) {
 	httpClient := serviceInstance.config.Client(context.Background(), oauthToken)
-	httpResponse, httpError := httpClient.Get("https://www.googleapis.com/oauth2/v2/userinfo")
+	httpResponse, httpError := httpClient.Get(userInfoEndpoint)
 	if httpError != nil {
 		return nil, fmt.Errorf("failed to get user info: %w", httpError)
 	}

--- a/pkg/gauss/service_test.go
+++ b/pkg/gauss/service_test.go
@@ -1,0 +1,57 @@
+package gauss
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestGenerateStateUnique(t *testing.T) {
+	svc, err := NewService("id", "secret", "http://example.com", "/dash", "")
+	if err != nil {
+		t.Fatalf("NewService error: %v", err)
+	}
+	a, err := svc.GenerateState()
+	if err != nil {
+		t.Fatalf("GenerateState error: %v", err)
+	}
+	b, err := svc.GenerateState()
+	if err != nil {
+		t.Fatalf("GenerateState error: %v", err)
+	}
+	if a == b {
+		t.Errorf("expected unique states, got %s and %s", a, b)
+	}
+}
+
+func TestGetUser(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"email":   "e@example.com",
+			"name":    "tester",
+			"picture": "img",
+		})
+	}))
+	defer server.Close()
+
+	orig := userInfoEndpoint
+	userInfoEndpoint = server.URL
+	defer func() { userInfoEndpoint = orig }()
+
+	svc, err := NewService("id", "secret", "http://example.com", "/dash", "")
+	if err != nil {
+		t.Fatalf("NewService error: %v", err)
+	}
+	tok := &oauth2.Token{AccessToken: "abc"}
+	user, err := svc.GetUser(tok)
+	if err != nil {
+		t.Fatalf("GetUser error: %v", err)
+	}
+	if user.Email != "e@example.com" || user.Name != "tester" {
+		t.Fatalf("unexpected user: %+v", user)
+	}
+}

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -1,0 +1,22 @@
+package session
+
+import (
+	"testing"
+)
+
+func TestStorePanicsWithoutInit(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic when store is nil")
+		}
+	}()
+	Store()
+}
+
+func TestNewSessionAndStore(t *testing.T) {
+	secret := []byte("secret")
+	NewSession(secret)
+	if Store() == nil {
+		t.Fatal("store should not be nil after initialization")
+	}
+}


### PR DESCRIPTION
## Summary
- add tests covering session package, gauss service, handlers, and middleware
- allow overriding Google userinfo endpoint for testability

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a80910b9c8327a396c3c3e66b795a