### PR TITLE
chore(GAuss): ensure gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 .idea/
 *.iml
 .env
+# Managed by gix gitignore workflow
+.env.*
+.DS_Store
+qodana.yaml
+tools/
+bin/


### PR DESCRIPTION
Ensure `.gitignore` contains the standard secrets/tooling entries (.env, tools/, bin/).